### PR TITLE
Fix settings migration

### DIFF
--- a/octoprint_tplinksmartplug/__init__.py
+++ b/octoprint_tplinksmartplug/__init__.py
@@ -63,7 +63,7 @@ class tplinksmartplugPlugin(octoprint.plugin.SettingsPlugin,
 		if current is None or current < self.get_settings_version():
 			# Reset plug settings to defaults.
 			self._logger.debug("Resetting arrSmartplugs for tplinksmartplug settings.")
-			self._settings.set(['arrSmartplugs'], self.get_settings_defaults().arrSmartplugs)
+			self._settings.set(['arrSmartplugs'], self.get_settings_defaults()["arrSmartplugs"])
 		
 	##~~ AssetPlugin mixin
 


### PR DESCRIPTION
Your default settings are an array. You cannot access keys of a map via `.foo`in python, you need to use `['foo']`.

Now, this at least makes things functional again for me here against 1.3.5 with regards to #19. In general I'd suggest though that you give things a test drive both with established settings and without (best create a whole new basefolder for testing this, `octoprint serve --help` is your friend here) before you push this as a new release, to ensure stuff really works and doesn't throw JavaScript errors on the console or exceptions in the backend.