### PR TITLE
0.9.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.9.2] - 2018-02-03
+## [0.9.4] - 2018-06-09
+### Changed
+- If M81 command is received to power off plug with a configured delay and `Warn While Printing` is enabled the plug will not be powered off if another print is started before the delay is reached.
+
+## [0.9.3] - 2018-02-03
 ### Fixed
 - Icon not displaying in IE due to binding css issue.
 
@@ -120,6 +124,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial release.
 
+[0.9.4]: https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/tree/0.9.4
+[0.9.3]: https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/tree/0.9.3
 [0.9.2]: https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/tree/0.9.2
 [0.9.1]: https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/tree/0.9.1
 [0.8.0]: https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/tree/0.8.0

--- a/octoprint_tplinksmartplug/__init__.py
+++ b/octoprint_tplinksmartplug/__init__.py
@@ -212,6 +212,12 @@ class tplinksmartplugPlugin(octoprint.plugin.SettingsPlugin,
 			
 	##~~ Gcode processing hook
 	
+	def gcode_turn_off(self, plug):
+		if plug["warnPrinting"] and self._printer.is_printing():
+			self._logger.info("Not powering off %s because printer is printing." % plug["label"])
+		else:
+			self.turn_off(plug["ip"])
+	
 	def processGCODE(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
 		if gcode:
 			if cmd.startswith("M80"):			
@@ -229,7 +235,7 @@ class tplinksmartplugPlugin(octoprint.plugin.SettingsPlugin,
 				plug = self.plug_search(self._settings.get(["arrSmartplugs"]),"ip",plugip)
 				self._tplinksmartplug_logger.debug(plug)
 				if plug["gcodeEnabled"]:
-					t = threading.Timer(int(plug["gcodeOffDelay"]),self.turn_off,args=[plugip])
+					t = threading.Timer(int(plug["gcodeOffDelay"]),self.gcode_turn_off,[plug])
 					t.start()
 				return
 			else:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tplinksmartplug"
 plugin_name = "OctoPrint-TPLinkSmartplug"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.9.3"
+plugin_version = "0.9.4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
If M81 command is received to power off plug with a configured delay and `Warn While Printing` is enabled the plug will not be powered off if another print is started before the delay is reached.