### PR TITLE
0.9.8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.9.8] - 2018-11-18
+### Fixed
+- Non Energy Monitoring devices were causing errors on status checks resulting in status update failure.
+
+### Issues
+- When toggling energy monitoring devices on/off the energy usage reported in the sidebar panel is from prior to the status change, so off plugs aren't reporting 0 as expected. Upon the next polling interval the power usage shoould be back in sync.
+
 ## [0.9.7] - 2018-11-03
 ### Added
 - Added energy monitoring support for the HS-110 devices.  Plugs' statuses will be checked on startup, on toggle of on/off, on print progress, and on polling interval configured in settings.  
@@ -139,6 +146,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial release.
 
+[0.9.8]: https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/tree/0.9.8
 [0.9.7]: https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/tree/0.9.7
 [0.9.6]: https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/tree/0.9.6
 [0.9.5]: https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/tree/0.9.5

--- a/octoprint_tplinksmartplug/static/css/tplinksmartplug.css
+++ b/octoprint_tplinksmartplug/static/css/tplinksmartplug.css
@@ -14,3 +14,9 @@
 	border-top: none;
 	vertical-align: top;
 }
+
+div#tplinksmartplugs div:not(:last-child) {
+	margin-bottom: 10px;
+	padding-bottom: 10px;
+	border-bottom: 1px solid #DDD;
+}

--- a/octoprint_tplinksmartplug/static/js/tplinksmartplug.js
+++ b/octoprint_tplinksmartplug/static/js/tplinksmartplug.js
@@ -5,42 +5,64 @@
  * License: AGPLv3
  */
 $(function() {
-    function tplinksmartplugViewModel(parameters) {
-        var self = this;
+	function tplinksmartplugViewModel(parameters) {
+		var self = this;
 
-        self.settings = parameters[0];
+		self.settings = parameters[0];
 		self.loginState = parameters[1];
 
 		self.arrSmartplugs = ko.observableArray();
 		self.isPrinting = ko.observable(false);
 		self.selectedPlug = ko.observable();
 		self.processing = ko.observableArray([]);
+		self.show_sidebar = ko.computed(function(){
+			var energy_monitoring_enabled = ko.utils.arrayFilter(self.arrSmartplugs(), function(item) {
+						if (item.emeter){
+							return "get_realtime" in item.emeter;
+						} else {
+							return false;
+						}
+					});
+			return energy_monitoring_enabled.length > 0;
+		});
+		self.get_power = function(data){
+			if("power" in data.emeter.get_realtime){
+				return data.emeter.get_realtime.power().toFixed(2);
+			} else if ("power_mw" in data.emeter.get_realtime) {
+				return (data.emeter.get_realtime.power_mw()/1000).toFixed(2);
+			} else {
+				return "-"
+			}
+		}
+		self.get_kwh = function(data){
+			if("total" in data.emeter.get_realtime){
+				return data.emeter.get_realtime.total().toFixed(2);
+			} else if ("total_wh" in data.emeter.get_realtime) {
+				return (data.emeter.get_realtime.total_wh()/1000).toFixed(2);
+			} else {
+				return "-"
+			}
+		}
 /* 		self.energy_data = function(data){
 			var output = data.label() + '<br/>';
 			var energy_data = ko.toJS(data.emeter);
 			for (x in energy_data){output += x + ': ' + energy_data[x] + '<br/>'};
 			return output;
 		} */
-		
-		self.onStartup = function() {
-			var element = $("#state").find(".accordion-inner .progress");
-			if (element.length) {
-				element.before('<div class="row-fluid" data-bind="foreach: settings.settings.plugins.tplinksmartplug.arrSmartplugs"><!-- ko if: emeter.get_realtime --><div class="row-fluid"><hr>Plug: <strong data-bind="text: label"></strong><br>Current Power: <strong data-bind="text: emeter.get_realtime.power"></strong> W<br>Total Consumption: <strong data-bind="text: emeter.get_realtime.total"></strong> kWh</div><!-- /ko --></div>');
-			}
-		};
-		
-		self.onBeforeBinding = function() {		
+
+		self.onBeforeBinding = function() {
 			self.arrSmartplugs(self.settings.settings.plugins.tplinksmartplug.arrSmartplugs());
-        }
-		
-		self.onAfterBinding = function() {
-			self.checkStatuses();
 		}
 
-        self.onEventSettingsUpdated = function(payload) {
+		self.onAfterBinding = function() {
+			self.checkStatuses();
+			console.log(self.show_sidebar());
+		}
+
+		self.onEventSettingsUpdated = function(payload) {
 			self.arrSmartplugs(self.settings.settings.plugins.tplinksmartplug.arrSmartplugs());
 		}
-		
+
 		self.onEventPrinterStateChanged = function(payload) {
 			if (payload.state_id == "PRINTING" || payload.state_id == "PAUSED"){
 				self.isPrinting(true);
@@ -48,16 +70,16 @@ $(function() {
 				self.isPrinting(false);
 			}
 		}
-		
+
 		self.cancelClick = function(data) {
 			self.processing.remove(data.ip());
 		}
-		
+
 		self.editPlug = function(data) {
 			self.selectedPlug(data);
 			$("#TPLinkPlugEditor").modal("show");
 		}
-		
+
 		self.addPlug = function() {
 			self.selectedPlug({'ip':ko.observable(''),
 									'label':ko.observable(''),
@@ -86,31 +108,29 @@ $(function() {
 			self.settings.settings.plugins.tplinksmartplug.arrSmartplugs.push(self.selectedPlug());
 			$("#TPLinkPlugEditor").modal("show");
 		}
-		
+
 		self.removePlug = function(row) {
 			self.settings.settings.plugins.tplinksmartplug.arrSmartplugs.remove(row);
 		}
-		
+
 		self.onDataUpdaterPluginMessage = function(plugin, data) {
-            if (plugin != "tplinksmartplug") {
-                return;
-            }
-			
+			if (plugin != "tplinksmartplug") {
+				return;
+			}
+
 			plug = ko.utils.arrayFirst(self.settings.settings.plugins.tplinksmartplug.arrSmartplugs(),function(item){
 				return item.ip() === data.ip;
 				}) || {'ip':data.ip,'currentState':'unknown','btnColor':'#808080'};
-			
-			if(data.emeter){
-				console.log(data.emeter);
-				if(plug.emeter != data.emeter){
-					plug.emeter = data.emeter;
-					self.settings.saveData();
-				}
-				return;
-			}
-			
-			if (plug.currentState != data.currentState) {
-				plug.currentState(data.currentState)
+
+			console.log(ko.toJSON(plug));
+			console.log(data);
+
+			if ((plug.currentState() != data.currentState) || (plug.emeter != data.emeter)) {
+				console.log('Changing state and emeter data.');
+				plug.currentState(data.currentState);
+				plug.emeter = data.emeter;
+				console.log(ko.toJSON(plug));
+				self.settings.saveData();
 				switch(data.currentState) {
 					case "on":
 						break;
@@ -123,12 +143,11 @@ $(function() {
 							type: 'error',
 							hide: true
 							});
-				self.settings.saveData();
 				}
 			}
 			self.processing.remove(data.ip);
-        };
-		
+		};
+
 		self.toggleRelay = function(data) {
 			self.processing.push(data.ip());
 			switch(data.currentState()){
@@ -142,28 +161,28 @@ $(function() {
 					self.checkStatus(data.ip());
 			}
 		}
-		
+
 		self.turnOn = function(data) {
 /* 			if(data.sysCmdOn()){
 				setTimeout(function(){self.sysCommand(data.sysRunCmdOn())},data.sysCmdOnDelay()*1000);
 			} */
 			self.sendTurnOn(data);
 		}
-		
-		self.sendTurnOn = function(data) {
-            $.ajax({
-                url: API_BASEURL + "plugin/tplinksmartplug",
-                type: "POST",
-                dataType: "json",
-                data: JSON.stringify({
-                    command: "turnOn",
-					ip: data.ip()
-                }),
-                contentType: "application/json; charset=UTF-8"
-            });
-        };
 
-    	self.turnOff = function(data) {
+		self.sendTurnOn = function(data) {
+			$.ajax({
+				url: API_BASEURL + "plugin/tplinksmartplug",
+				type: "POST",
+				dataType: "json",
+				data: JSON.stringify({
+					command: "turnOn",
+					ip: data.ip()
+				}),
+				contentType: "application/json; charset=UTF-8"
+			});
+		};
+
+		self.turnOff = function(data) {
 			if((data.displayWarning() || (self.isPrinting() && data.warnPrinting())) && !$("#TPLinkSmartPlugWarning").is(':visible')){
 				self.selectedPlug(data);
 				$("#TPLinkSmartPlugWarning").modal("show");
@@ -174,8 +193,8 @@ $(function() {
 				} */
 				self.sendTurnOff(data);
 			}
-        }; 
-		
+		}; 
+
 		self.sendTurnOff = function(data) {
 			$.ajax({
 			url: API_BASEURL + "plugin/tplinksmartplug",
@@ -186,61 +205,24 @@ $(function() {
 				ip: data.ip()
 			}),
 			contentType: "application/json; charset=UTF-8"
-			});		
+			});
 		}
-		
+
 		self.checkStatus = function(plugIP) {
-            $.ajax({
-                url: API_BASEURL + "plugin/tplinksmartplug",
-                type: "POST",
-                dataType: "json",
-                data: JSON.stringify({
-                    command: "checkStatus",
+			$.ajax({
+				url: API_BASEURL + "plugin/tplinksmartplug",
+				type: "POST",
+				dataType: "json",
+				data: JSON.stringify({
+					command: "checkStatus",
 					ip: plugIP
-                }),
-                contentType: "application/json; charset=UTF-8"
-            }).done(function(){
+				}),
+				contentType: "application/json; charset=UTF-8"
+			}).done(function(){
 				self.settings.saveData();
 				});
-        }; 
-		
-		self.disconnectPrinter = function() {
-            $.ajax({
-                url: API_BASEURL + "plugin/tplinksmartplug",
-                type: "POST",
-                dataType: "json",
-                data: JSON.stringify({
-                    command: "disconnectPrinter"
-                }),
-                contentType: "application/json; charset=UTF-8"
-            });			
-		}
-		
-		self.connectPrinter = function() {
-            $.ajax({
-                url: API_BASEURL + "plugin/tplinksmartplug",
-                type: "POST",
-                dataType: "json",
-                data: JSON.stringify({
-                    command: "connectPrinter"
-                }),
-                contentType: "application/json; charset=UTF-8"
-            });			
-		}
-		
-/* 		self.sysCommand = function(sysCmd) {
-            $.ajax({
-                url: API_BASEURL + "plugin/tplinksmartplug",
-                type: "POST",
-                dataType: "json",
-                data: JSON.stringify({
-                    command: "sysCommand",
-					cmd: sysCmd
-                }),
-                contentType: "application/json; charset=UTF-8"
-            });			
-		} */
-		
+		}; 
+
 		self.checkStatuses = function() {
 			ko.utils.arrayForEach(self.settings.settings.plugins.tplinksmartplug.arrSmartplugs(),function(item){
 				if(item.ip() !== "") {
@@ -251,17 +233,17 @@ $(function() {
 			if (self.settings.settings.plugins.tplinksmartplug.pollingEnabled()) {
 				setTimeout(function() {self.checkStatuses();}, (parseInt(self.settings.settings.plugins.tplinksmartplug.pollingInterval(),10) * 60000));
 			};
-        };
-    }
+		};
+	}
 
-    // view model class, parameters for constructor, container to bind to
-    OCTOPRINT_VIEWMODELS.push([
-        tplinksmartplugViewModel,
+	// view model class, parameters for constructor, container to bind to
+	OCTOPRINT_VIEWMODELS.push([
+		tplinksmartplugViewModel,
 
-        // e.g. loginStateViewModel, settingsViewModel, ...
-        ["settingsViewModel","loginStateViewModel"],
+		// e.g. loginStateViewModel, settingsViewModel, ...
+		["settingsViewModel","loginStateViewModel"],
 
-        // "#navbar_plugin_tplinksmartplug","#settings_plugin_tplinksmartplug"
-        ["#navbar_plugin_tplinksmartplug","#settings_plugin_tplinksmartplug"]
-    ]);
+		// "#navbar_plugin_tplinksmartplug","#settings_plugin_tplinksmartplug"
+		["#navbar_plugin_tplinksmartplug","#settings_plugin_tplinksmartplug","#sidebar_plugin_tplinksmartplug_wrapper"]
+	]);
 });

--- a/octoprint_tplinksmartplug/templates/tplinksmartplug_sidebar.jinja2
+++ b/octoprint_tplinksmartplug/templates/tplinksmartplug_sidebar.jinja2
@@ -1,0 +1,9 @@
+<div id="tplinksmartplugs" class="row-fluid" data-bind="foreach: settings.settings.plugins.tplinksmartplug.arrSmartplugs">
+	<!-- ko if: emeter.get_realtime -->
+		<div class="row-fluid">
+			Plug: <strong data-bind="text: label"></strong><br/>
+			Current Power: <strong data-bind="text: $root.get_power($data)"></strong> W<br/>
+			Total Consumption: <strong data-bind="text: $root.get_kwh($data)"></strong> kWh
+		</div>
+	<!-- /ko -->
+</div>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tplinksmartplug"
 plugin_name = "OctoPrint-TPLinkSmartplug"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.9.7"
+plugin_version = "0.9.8"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
### Fixed
- Non Energy Monitoring devices were causing errors on status checks resulting in status update failure. Resolves #68, Might Resolve #69.

### Issues
- When toggling energy monitoring devices on/off the energy usage reported in the sidebar panel is from prior to the status change, so off plugs aren't reporting 0 as expected. Upon the next polling interval the power usage shoould be back in sync.