### PR TITLE
Add uptime check to prevent early power off

### DIFF
--- a/octoprint_tplinksmartplug/__init__.py
+++ b/octoprint_tplinksmartplug/__init__.py
@@ -731,6 +731,15 @@ class tplinksmartplugPlugin(octoprint.plugin.SettingsPlugin,
 		if self._printer.is_printing() or self._printer.is_paused():
 			return
 
+        f = open("/proc/uptime", "r")
+        uptime_seconds = float(f.readline().split()[0])
+        f.close()
+        timeout = (self._settings.get_int(["idleTimeout"]) * 60)
+        if int(uptime_seconds) <= timeout:
+            self._tplinksmartplug_logger.debug("Just booted so wait for time sync.")
+            self._reset_idle_timer()
+            return
+
 		self._tplinksmartplug_logger.debug(
 			"Idle timeout reached after %s minute(s). Turning heaters off prior to powering off plugs." % self.idleTimeout)
 		if self._wait_for_heaters():


### PR DESCRIPTION
Raspberry Pi's don't come with an RTC and therefore time is all
over the place on startup. This causes a jump which triggers the
poweroff code. This commit adds a check to diff uptime against the
user-set timeout and to wait until that has passed.

This is probably a very inelegant way of doing this as it assumes
that /proc/uptime exists and the user has set a timeout. We could
just force it to wait for a minute to allow ntp to sync.